### PR TITLE
Migrate Core project to .NET Standard 1.0

### DIFF
--- a/Synergy.Contracts/ExcludeFromCodeCoverageAttribute.cs
+++ b/Synergy.Contracts/ExcludeFromCodeCoverageAttribute.cs
@@ -1,0 +1,8 @@
+﻿namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>Specifies that the attributed code should be excluded from code coverage information. </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Event, AllowMultiple = false, Inherited = false)]
+    public sealed class ExcludeFromCodeCoverageAttribute : Attribute
+    {
+    }
+}

--- a/Synergy.Contracts/Extensions/TypeExtensions.cs
+++ b/Synergy.Contracts/Extensions/TypeExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Reflection;
+
+namespace Synergy.Contracts.Extensions
+{
+    internal static class TypeExtensions
+    {
+        public static bool IsInstanceOfType(this Type type, object obj)
+        {
+            return obj != null && type.GetTypeInfo().IsAssignableFrom(obj.GetType().GetTypeInfo());
+        }
+    }
+}

--- a/Synergy.Contracts/Failures/DesignByContractViolationException.cs
+++ b/Synergy.Contracts/Failures/DesignByContractViolationException.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Diagnostics;
-using System.Runtime.Serialization;
 using JetBrains.Annotations;
 
 namespace Synergy.Contracts
@@ -9,7 +8,6 @@ namespace Synergy.Contracts
     /// The exception thrown when some contract check failed.
     /// When you see it it means that someone does not meet the contract.
     /// </summary>
-    [Serializable]
     [DebuggerStepThrough]
     public class DesignByContractViolationException : Exception
     {
@@ -25,14 +23,6 @@ namespace Synergy.Contracts
         /// </summary>
         /// <param name="message"></param>
         public DesignByContractViolationException([NotNull] string message) : base(message)
-        {
-        }
-
-        /// <summary>
-        /// Serialization required constructor.
-        /// </summary>
-        protected DesignByContractViolationException([NotNull] SerializationInfo info, StreamingContext context) :
-            base(info, context)
         {
         }
     }

--- a/Synergy.Contracts/Failures/FailCastable.cs
+++ b/Synergy.Contracts/Failures/FailCastable.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using JetBrains.Annotations;
+using Synergy.Contracts.Extensions;
 
 namespace Synergy.Contracts
 {

--- a/Synergy.Contracts/Synergy.Contracts.csproj
+++ b/Synergy.Contracts/Synergy.Contracts.csproj
@@ -1,16 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{653FF172-0DC5-4D81-91AE-3CE09D8CF7C1}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Synergy.Contracts</RootNamespace>
+    <TargetFramework>netstandard1.0</TargetFramework>
     <AssemblyName>Synergy.Contracts</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <RootNamespace>Synergy.Contracts</RootNamespace>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -35,42 +28,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="JetBrains.Annotations, Version=10.2.1.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Annotations.10.2.1\lib\net\JetBrains.Annotations.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
+    <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />
+    <PackageReference Include="JetBrains.Annotations" Version="10.2.1" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="..\SynergyAssemblyInfo.cs">
-      <Link>Properties\SynergyAssemblyInfo.cs</Link>
-    </Compile>
-    <Compile Include="Extensions\StringFormatExtensions.cs" />
-    <Compile Include="Failures\DesignByContractViolationException.cs" />
-    <Compile Include="Failures\Fail.cs" />
-    <Compile Include="Failures\FailEnum.cs" />
-    <Compile Include="Failures\FailString.cs" />
-    <Compile Include="Failures\FailBoolean.cs" />
-    <Compile Include="Failures\FailCastable.cs" />
-    <Compile Include="Failures\FailCollection.cs" />
-    <Compile Include="Failures\FailDateTime.cs" />
-    <Compile Include="Failures\FailEquality.cs" />
-    <Compile Include="Failures\FailGuid.cs" />
-    <Compile Include="Failures\FailNullability.cs" />
-    <Compile Include="Pooling\Pool.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-    <None Include="Synergy.Contracts.nuspec" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/Synergy.Contracts/packages.config
+++ b/Synergy.Contracts/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="JetBrains.Annotations" version="10.2.1" targetFramework="net452" />
-</packages>


### PR DESCRIPTION
#18 

Udało się na .NET Standard 1.0 (czyli każdy klient będzie mógł z tego korzystać). Poniżej description z commita wraz z linkami dlaczego tak zrobiłem.

To make it work things needs to be done:
* Completely remove SerializationAttribute - z https://stackoverflow.com/questions/39199049/what-is-the-equivalent-of-serializable-in-net-core-conversion-projects zrozumiałem że nie trzeba tego implementować
* Create custom IsInstanceOfType (API has changed)
* Create own ExcludeFromCodeCoverage
(tools rely more on name than concrete type with namespace) - tak zrozumiałem z dyskusji https://github.com/dotnet/corefx/issues/14488
