### PR TITLE
migrate to netstandard2

### DIFF
--- a/Synergy.Contracts.Samples/Synergy.Contracts.Samples.csproj
+++ b/Synergy.Contracts.Samples/Synergy.Contracts.Samples.csproj
@@ -1,68 +1,27 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{B585BA9B-E3CC-4CE0-AE48-035C13C08B7E}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Synergy.Contracts.Samples</RootNamespace>
-    <AssemblyName>Synergy.Contracts.Samples</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ProjectGuid>{B585BA9B-E3CC-4CE0-AE48-035C13C08B7E}</ProjectGuid>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="JetBrains.Annotations, Version=10.2.1.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Annotations.10.2.1\lib\net\JetBrains.Annotations.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
+    <ProjectReference Include="..\Synergy.Contracts\Synergy.Contracts.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\SynergyAssemblyInfo.cs">
-      <Link>Properties\SynergyAssemblyInfo.cs</Link>
-    </Compile>
-    <Compile Include="Annotations\SourceTemplateAttributeSample.cs" />
-    <Compile Include="ContractorRepository.cs" />
-    <Compile Include="Domain\Address.cs" />
-    <Compile Include="Domain\Contractor.cs" />
-    <Compile Include="Domain\ContractorType.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
+    <PackageReference Include="JetBrains.Annotations" Version="10.2.1" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Synergy.Contracts\Synergy.Contracts.csproj">
-      <Project>{653ff172-0dc5-4d81-91ae-3ce09d8cf7c1}</Project>
-      <Name>Synergy.Contracts</Name>
-    </ProjectReference>
+    <Compile Include="..\SynergyAssemblyInfo.cs" Link="Properties\SynergyAssemblyInfo.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/Synergy.Contracts.Samples/packages.config
+++ b/Synergy.Contracts.Samples/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="JetBrains.Annotations" version="10.2.1" targetFramework="net452" />
-</packages>

--- a/Synergy.Contracts.Test/Synergy.Contracts.Test.csproj
+++ b/Synergy.Contracts.Test/Synergy.Contracts.Test.csproj
@@ -1,83 +1,29 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{6FFB403F-FFDE-44A5-B3DA-C16F008CA8FE}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Synergy.Contracts.Test</RootNamespace>
-    <AssemblyName>Synergy.Contracts.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <TargetFramework>net462</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ProjectGuid>{6FFB403F-FFDE-44A5-B3DA-C16F008CA8FE}</ProjectGuid>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="JetBrains.Annotations, Version=10.2.1.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Annotations.10.2.1\lib\net\JetBrains.Annotations.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
+    <ProjectReference Include="..\Synergy.Contracts.Samples\Synergy.Contracts.Samples.csproj" />
+    <ProjectReference Include="..\Synergy.Contracts\Synergy.Contracts.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="!Init\settings.cs" />
-    <Compile Include="..\SynergyAssemblyInfo.cs">
-      <Link>Properties\SynergyAssemblyInfo.cs</Link>
-    </Compile>
-    <Compile Include="Failures\FailStringTest.cs" />
-    <Compile Include="Failures\FailBooleanTest.cs" />
-    <Compile Include="Failures\FailCastableTest.cs" />
-    <Compile Include="Failures\FailCollectionTest.cs" />
-    <Compile Include="Failures\FailDateTimeTest.cs" />
-    <Compile Include="Failures\FailEqualityTest.cs" />
-    <Compile Include="Failures\FailGuidTest.cs" />
-    <Compile Include="Failures\FailNullabilityTest.cs" />
-    <Compile Include="Failures\FailEnumTest.cs" />
-    <Compile Include="Failures\FailTest.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
+    <PackageReference Include="JetBrains.Annotations" Version="10.2.1" />
+    <PackageReference Include="NUnit" Version="3.5.0" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <Compile Include="..\SynergyAssemblyInfo.cs" Link="Properties\SynergyAssemblyInfo.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Synergy.Contracts.Samples\Synergy.Contracts.Samples.csproj">
-      <Project>{b585ba9b-e3cc-4ce0-ae48-035c13c08b7e}</Project>
-      <Name>Synergy.Contracts.Samples</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Synergy.Contracts\Synergy.Contracts.csproj">
-      <Project>{653ff172-0dc5-4d81-91ae-3ce09d8cf7c1}</Project>
-      <Name>Synergy.Contracts</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/Synergy.Contracts.Test/packages.config
+++ b/Synergy.Contracts.Test/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="JetBrains.Annotations" version="10.2.1" targetFramework="net452" />
-  <package id="NUnit" version="3.5.0" targetFramework="net452" />
-</packages>

--- a/Synergy.Contracts/ExcludeFromCodeCoverageAttribute.cs
+++ b/Synergy.Contracts/ExcludeFromCodeCoverageAttribute.cs
@@ -1,8 +1,0 @@
-﻿namespace System.Diagnostics.CodeAnalysis
-{
-    /// <summary>Specifies that the attributed code should be excluded from code coverage information. </summary>
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Event, AllowMultiple = false, Inherited = false)]
-    public sealed class ExcludeFromCodeCoverageAttribute : Attribute
-    {
-    }
-}

--- a/Synergy.Contracts/Extensions/TypeExtensions.cs
+++ b/Synergy.Contracts/Extensions/TypeExtensions.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Reflection;
+using JetBrains.Annotations;
 
 namespace Synergy.Contracts.Extensions
 {
     internal static class TypeExtensions
     {
-        public static bool IsInstanceOfType(this Type type, object obj)
+        public static bool IsInstanceOfType(this Type type, [CanBeNull] object obj)
         {
             return obj != null && type.GetTypeInfo().IsAssignableFrom(obj.GetType().GetTypeInfo());
         }

--- a/Synergy.Contracts/Synergy.Contracts.csproj
+++ b/Synergy.Contracts/Synergy.Contracts.csproj
@@ -28,7 +28,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />
     <PackageReference Include="JetBrains.Annotations" Version="10.2.1" />
   </ItemGroup>
 </Project>

--- a/Synergy.Contracts/Synergy.Contracts.csproj
+++ b/Synergy.Contracts/Synergy.Contracts.csproj
@@ -1,9 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <AssemblyName>Synergy.Contracts</AssemblyName>
     <RootNamespace>Synergy.Contracts</RootNamespace>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -13,7 +14,6 @@
     <DefineConstants>TRACE;DEBUG;CODE_ANALYSIS;JETBRAINS_ANNOTATIONS;INTERNAL_POOL</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DocumentationFile>bin\Debug\Synergy.Contracts.XML</DocumentationFile>
   </PropertyGroup>


### PR DESCRIPTION
Changes:
- Convert Sample and Test to vs2017 project format. 
- Remove duplicated `ExcludeFromCodeCoverageAttribute`. 
- Disable FxCope analysis. Convert Synergy.Contracts to multi-target project to support `netstandard2.0` and `net462`
- Remove unnecessary dependency to `Microsoft.NETCore.Portable.Compatibility`
